### PR TITLE
fe_12_localstorage-persistence-for-settings

### DIFF
--- a/src/features/settings/context/AccessibilityContext.tsx
+++ b/src/features/settings/context/AccessibilityContext.tsx
@@ -4,19 +4,26 @@ import React, { createContext, useContext, useState, useCallback } from 'react';
 import type { FontSize, ContrastMode } from '@/types';
 import type { AccessibilityContextValue } from '../types/settings.types';
 import { DEFAULT_FONT_SIZE, DEFAULT_CONTRAST_MODE } from '@/lib/constants';
+import { getStorageItem, setStorageItem } from '@/lib/utils/localStorage';
 
 const AccessibilityContext = createContext<AccessibilityContextValue | undefined>(undefined);
 
 export function AccessibilityProvider({ children }: { children: React.ReactNode }) {
-  const [fontSize, setFontSizeState] = useState<FontSize>(DEFAULT_FONT_SIZE);
-  const [contrastMode, setContrastModeState] = useState<ContrastMode>(DEFAULT_CONTRAST_MODE);
+  const [fontSize, setFontSizeState] = useState<FontSize>(
+    () => getStorageItem<FontSize>('accessibility_fontSize', DEFAULT_FONT_SIZE)
+  );
+  const [contrastMode, setContrastModeState] = useState<ContrastMode>(
+    () => getStorageItem<ContrastMode>('accessibility_contrastMode', DEFAULT_CONTRAST_MODE)
+  );
 
   const setFontSize = useCallback((size: FontSize) => {
     setFontSizeState(size);
+    setStorageItem('accessibility_fontSize', size);
   }, []);
 
   const setContrastMode = useCallback((mode: ContrastMode) => {
     setContrastModeState(mode);
+    setStorageItem('accessibility_contrastMode', mode);
   }, []);
 
   return (

--- a/src/lib/utils/localStorage.ts
+++ b/src/lib/utils/localStorage.ts
@@ -1,0 +1,30 @@
+const STORAGE_PREFIX = 'inclusiveGO_';
+
+export function getStorageItem<T>(key: string, fallback: T): T {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const item = localStorage.getItem(STORAGE_PREFIX + key);
+    if (item === null) return fallback;
+    return JSON.parse(item) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function setStorageItem<T>(key: string, value: T): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(value));
+  } catch {
+    // Silently fail (e.g. quota exceeded in private browsing)
+  }
+}
+
+export function removeStorageItem(key: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(STORAGE_PREFIX + key);
+  } catch {
+    // Silently fail
+  }
+}


### PR DESCRIPTION
Initialize state from localStorage, use a lazy initializer on useState that calls getStorageItem with the existing defaults as fallbacks:

- Key accessibility_fontSize, fallback DEFAULT_FONT_SIZE

- Key accessibility_contrastMode, fallback DEFAULT_CONTRAST_MODE

- Persist on change in setFontSize and setContrastMode callbacks, call setStorageItem alongside the state setter. No extra useEffect needed.

No other changes the context interface (AccessibilityContextValue) stays the same; consumers are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Accessibility settings now persist across browser sessions, automatically preserving your configured preferences whenever you return to the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->